### PR TITLE
style: Adjust padding between messages

### DIFF
--- a/src/renderer/src/components/ChatMessage.jsx
+++ b/src/renderer/src/components/ChatMessage.jsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
-import { Box, Paper, IconButton, Tooltip } from '@mui/material'
+import { Box, Paper, IconButton, Tooltip, useTheme } from '@mui/material'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 const ChatMessage = ({ msg }) => {
   const [tooltipText, setTooltipText] = useState('Copy message')
+  const theme = useTheme()
 
   // Function to copy text to clipboard
   const handleCopy = async () => {
@@ -37,7 +38,10 @@ const ChatMessage = ({ msg }) => {
           padding: '2px 8px',
           maxWidth: '80%',
           marginBottom: '20px',
-          backgroundColor: msg.role === 'user' ? 'chat.user' : 'chat.assistant',
+          backgroundColor:
+            msg.role === 'user'
+              ? theme.palette.chat.user[theme.palette.mode]
+              : theme.palette.chat.assistant[theme.palette.mode],
           position: 'relative' // Needed for absolute positioning of copy icon
         }}
       >

--- a/src/renderer/src/components/ChatMessage.jsx
+++ b/src/renderer/src/components/ChatMessage.jsx
@@ -36,7 +36,7 @@ const ChatMessage = ({ msg }) => {
         sx={{
           padding: '2px 8px',
           maxWidth: '80%',
-          marginBottom: '8px',
+          marginBottom: '20px',
           backgroundColor: msg.role === 'user' ? 'chat.user' : 'chat.assistant',
           position: 'relative' // Needed for absolute positioning of copy icon
         }}

--- a/src/renderer/src/components/ConversationDisplay.jsx
+++ b/src/renderer/src/components/ConversationDisplay.jsx
@@ -9,7 +9,7 @@ const ConversationDisplay = ({ chat, isLoading, planningStatus, chatEndRef }) =>
         mb: 1,
         height: 'calc(100vh - 250px)',
         overflowY: 'auto',
-        paddingBottom: '32px'
+        paddingBottom: '20px'
       }}
     >
       {chat.slice(1).map((msg, idx) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Chat messages now use theme-aware colors for user and assistant, improving readability in light and dark modes.
  * Increased spacing beneath each message for clearer separation.
  * Reduced extra space at the bottom of the conversation view for a tighter layout.
* **Refactor**
  * Integrated app-wide theming into chat message styling without changing behavior or copy-to-clipboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->